### PR TITLE
Support all JetBrains products

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ allprojects {
 
 dependencies {
     compile('io.vavr:vavr:0.9.2')
+    // force-pull org.apache.commons.lang3.StringUtils - seems to not exist in all jetbrains-products
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 0.1-SNAPSHOT
+version = 0.2-SNAPSHOT
 ideaVersion = 2017.3.5
 javaVersion = 1.8
 javaTargetVersion = 1.8

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.outskirtslabs.beancount</id>
     <name>Beancount</name>
-    <version>0.1</version>
+    <version>0.2</version>
     <vendor email="unnamedrambler@gmail.com" url="https://caseylink.com">Casey Link</vendor>
 
     <description><![CDATA[

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -29,9 +29,8 @@
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
-    <!-- uncomment to enable plugin in all products
+    <!-- enable plugin in all products -->
     <depends>com.intellij.modules.lang</depends>
-    -->
 
     <!--@formatter:off-->
   <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Allow to function on ALL jetbrains-products
- force-pull `org.apache.commons.lang3.StringUtils` - seems to not exist in all jetbrains-products
- depend on `com.intellij.modules.lang` to not be a "legacy plugin"

Tested on IDEA, PyCharm, RubyMine & PHPStorm