### PR TITLE
add IDEA project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ lib
 
 notes.md
 *~
+
+# IDEA-specifics https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems
+.idea/dictionaries/
+.idea/tasks.xml
+.idea/usage.statistics.xml
+.idea/workspace.xml

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="org.jetbrains.plugins.gradle" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+          </set>
+        </option>
+        <option name="useAutoImport" value="true" />
+        <option name="useQualifiedModuleNames" value="true" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/classes" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ allprojects {
         version ideaVersion
         // always have these plugins installed
         plugins = [
-                "IdeaVIM:0.49",
                 "PsiViewer:3.28.93"]
         downloadSources Boolean.valueOf(sources)
         pluginName 'intellij-beancount'


### PR DESCRIPTION
Currently IDEA(2019.1) does not recognize this directory as "plugin" when attempting to open it.

With this it does, and pulls in `plugins.gradle` while its at it.


Based on IDEA-CE 2019.1.3